### PR TITLE
Can't parse get type request

### DIFF
--- a/lib/connect-php.js
+++ b/lib/connect-php.js
@@ -18,8 +18,8 @@ module.exports = function phpMiddleware(directory) {
         };
     }
     return function(req, res, next) {
-        if(req.url.endsWith('.php')) {
-            exec('php "' + directory + req.url + '"', function callback(error, stdout, stderr){
+        if(req._parsedUrl.pathname.endsWith('.php')) {
+            exec('php "' + directory + req._parsedUrl.pathname + '"', function callback(error, stdout, stderr){
                 if(error) {
                     console.error(stderr);
                 }


### PR DESCRIPTION
As [grunt-contrib-connect](https://www.npmjs.org/package/grunt-contrib-connect) middleware, it can't parse a request with some parameters, like a get type request. And I fixed it, please review.
